### PR TITLE
fix: kotlin and java version compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <kotlin.compiler.languageVersion>1.9</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>1.8</kotlin.compiler.apiVersion>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <java.version>21</java.version>
         <kotlin.version>2.1.20</kotlin.version>
         <jackson.version>2.18.3</jackson.version>
         <swagger.version>2.2.30</swagger.version>


### PR DESCRIPTION
### What
Decrease the required Java and Kotlin versions.

### Why
To allow projects with earlier versions to use the library without upgrading their Kotlin version or JRE.
