### PR TITLE
Revert "chore(deps): bump io.swagger.core.v3:swagger-core-jakarta from 2.2.42 to 2.2.48"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <jackson.version>2.21.2</jackson.version>
-        <swagger.version>2.2.48</swagger.version>
+        <swagger.version>2.2.42</swagger.version>
         <classgraph.version>4.8.184</classgraph.version>
         <mockk.version>1.14.6</mockk.version>
         <jsonassert.version>1.5.3</jsonassert.version>


### PR DESCRIPTION
Reverts asyncapi/kotlin-asyncapi#257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core library dependency version in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->