### PR TITLE
Revert "chore(deps): bump spring-framework.version from 7.0.8 to 7.0.9"

### DIFF
--- a/kotlin-asyncapi-spring-web/pom.xml
+++ b/kotlin-asyncapi-spring-web/pom.xml
@@ -15,7 +15,7 @@
     <description>The Spring Boot autoconfiguration for the Kotlin AsyncAPI framework</description>
 
     <properties>
-        <spring-framework.version>7.0.9</spring-framework.version>
+        <spring-framework.version>7.0.8</spring-framework.version>
         <spring-boot.version>4.1.0</spring-boot.version>
     </properties>
 


### PR DESCRIPTION
Reverts asyncapi/kotlin-asyncapi#316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Spring Framework version used by the Kotlin AsyncAPI Spring Web module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->